### PR TITLE
Adds NanoTrasen Branch

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -109,10 +109,10 @@
 	ideal_character_age = 60
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/cso
 	allowed_branches = list(
-		/datum/mil_branch/expeditionary_corps
+		/datum/mil_branch/nanotrasen
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/ec/o3
+		/datum/mil_rank/nt/scientist
 	)
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
@@ -147,7 +147,7 @@
 							 /datum/computer_file/program/reports)
 
 /datum/job/rd/get_description_blurb()
-	return "You are the Chief Science Officer. You are responsible for the research department. You handle the science aspects of the project and liase with the corporate interests of the Expeditionary Corps Organisation. Make sure science gets done, do some yourself, and get your scientists on away missions to find things to benefit the project. Advise the CO on science matters."
+	return "You are the Chief Science Officer. You are responsible for the research department. You handle the science aspects of the project and liase with the Representative and corporate interests in the program. Make sure science gets done, do some yourself, and get your scientists on away missions to find things to benefit the project. Advise the CO on science matters."
 
 /datum/job/cmo
 	title = "Chief Medical Officer"

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -10,8 +10,8 @@
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 25)
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/workplace_liaison
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	allowed_branches = list(/datum/mil_branch/nanotrasen)
+	allowed_ranks = list(/datum/mil_rank/nt/rep)
 	min_skill = list(   SKILL_BUREAUCRACY	= SKILL_EXPERT,
 	                    SKILL_FINANCE		= SKILL_BASIC)
 	skill_points = 20

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -25,10 +25,10 @@
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
 /datum/job/liaison/get_description_blurb()
-	return "You are the NanoTrasen Representative. You are a civilian employee of EXO, the Expeditionary Corps Organisation, the government-owned corporate conglomerate that partially funds the Torch. You are on board the vessel to promote corporate interests and protect the rights of the contractors on board as their union leader. You are not internal affairs. You advise command on corporate and union matters and contractors on their rights and obligations. Maximise profit. Be the shady corporate shill you always wanted to be."
+	return "You are the NanoTrasen Representative. You are a civilian employee of NanoTrasen, the conglomerate that partially funds the Torch. You are on board the vessel to promote corporate interests and protect the rights of NanoTrasen employees. You are not internal affairs. You advise command on corporate matters and employees on their rights and obligations. Maximise profit. Be the shady corporate shill you always wanted to be."
 
 /datum/job/liaison/post_equip_rank(var/mob/person, var/alt_title)
-	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Executive Assistant")]"]"
+	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Asset Protection Agent")]"]"
 	for(var/mob/M in GLOB.player_list)
 		if(M.client && M.mind)
 			if(M.mind.assigned_role == "Executive Assistant")

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -31,7 +31,7 @@
 	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Asset Protection Agent")]"]"
 	for(var/mob/M in GLOB.player_list)
 		if(M.client && M.mind)
-			if(M.mind.assigned_role == "Executive Assistant")
+			if(M.mind.assigned_role == "Asset Protection Agent")
 				to_chat(M, SPAN_NOTICE("<b>One of your employers, [my_title] named [person.real_name], is present on [GLOB.using_map.full_name].</b>"))
 	..()
 
@@ -70,7 +70,7 @@
 /datum/job/bodyguard/is_position_available()
 	if(..())
 		for(var/mob/M in GLOB.player_list)
-			if(M.client && M.mind && M.mind.assigned_role == "Workplace Liaison")
+			if(M.client && M.mind && M.mind.assigned_role == "NanoTrasen Representative")
 				return TRUE
 	return FALSE
 

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -1,5 +1,5 @@
 /datum/job/liaison
-	title = "Workplace Liaison"
+	title = "NanoTrasen Representative"
 	department = "Support"
 	department_flag = SPT
 	total_positions = 1
@@ -9,12 +9,6 @@
 	economic_power = 18
 	minimal_player_age = 0
 	minimum_character_age = list(SPECIES_HUMAN = 25)
-	alt_titles = list(
-		"Corporate Liaison",
-		"Union Representative",
-		"Corporate Representative",
-		"Corporate Executive"
-		)
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/workplace_liaison
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/contractor)
@@ -31,7 +25,7 @@
 	software_on_spawn = list(/datum/computer_file/program/reports)
 
 /datum/job/liaison/get_description_blurb()
-	return "You are the Workplace Liaison. You are a civilian employee of EXO, the Expeditionary Corps Organisation, the government-owned corporate conglomerate that partially funds the Torch. You are on board the vessel to promote corporate interests and protect the rights of the contractors on board as their union leader. You are not internal affairs. You advise command on corporate and union matters and contractors on their rights and obligations. Maximise profit. Be the shady corporate shill you always wanted to be."
+	return "You are the NanoTrasen Representative. You are a civilian employee of EXO, the Expeditionary Corps Organisation, the government-owned corporate conglomerate that partially funds the Torch. You are on board the vessel to promote corporate interests and protect the rights of the contractors on board as their union leader. You are not internal affairs. You advise command on corporate and union matters and contractors on their rights and obligations. Maximise profit. Be the shady corporate shill you always wanted to be."
 
 /datum/job/liaison/post_equip_rank(var/mob/person, var/alt_title)
 	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Executive Assistant")]"]"
@@ -42,19 +36,19 @@
 	..()
 
 /datum/job/bodyguard
-	title = "Executive Assistant"
+	title = "Asset Protection Agent"
 	department = "Support"
 	department_flag = SPT
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Workplace Liaison"
+	supervisors = "the NanoTrasen Representative"
 	selection_color = "#3d3d7f"
 	economic_power = 12
 	minimal_player_age = 7
 	minimum_character_age = list(SPECIES_HUMAN = 19)
 	outfit_type = /decl/hierarchy/outfit/job/torch/passenger/corporate_bodyguard
-	allowed_branches = list(/datum/mil_branch/civilian)
-	allowed_ranks = list(/datum/mil_rank/civ/contractor)
+	allowed_branches = list(/datum/mil_branch/nanotrasen)
+	allowed_ranks = list(/datum/mil_rank/nt/assetprotection)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_BASIC,
 	                    SKILL_COMBAT      = SKILL_BASIC,
@@ -63,11 +57,6 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
 	                    SKILL_WEAPONS     = SKILL_EXPERT,
 	                    SKILL_FORENSICS   = SKILL_EXPERT)
-	alt_titles = list(
-		"Union Enforcer",
-		"Loss Prevention Associate",
-		"Asset Protection Agent"
-	)
 	skill_points = 20
 
 	access = list(
@@ -86,12 +75,12 @@
 	return FALSE
 
 /datum/job/bodyguard/get_description_blurb()
-	return "You are the Executive Assistant. You are an employee of one of the corporations that make up the Expeditionary Corps Organisation, and your job is to assist the Liason in corporate affairs. You are also expected to protect the Liason's life, though not in any way that breaks the law."
+	return "You are the Asset Protection Agent. You are an employee of NanoTrasen, and your job is to assist the Representative in corporate affairs. You are also expected to protect the Representative's life, though not in any way that breaks the law."
 
 /datum/job/bodyguard/post_equip_rank(var/mob/person, var/alt_title)
-	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Executive Assistant")]"]"
+	var/my_title = "\a ["\improper [(person.mind ? (person.mind.role_alt_title ? person.mind.role_alt_title : person.mind.assigned_role) : "Asset Protection Agent")]"]"
 	for(var/mob/M in GLOB.player_list)
 		if(M.client && M.mind)
-			if(M.mind.assigned_role == "Workplace Liaison")
+			if(M.mind.assigned_role == "NanoTrasen Representative")
 				to_chat(M, SPAN_NOTICE("<b>Your bodyguard, [my_title] named [person.real_name], is present on [GLOB.using_map.full_name].</b>"))
 	..()

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -15,10 +15,10 @@
 		"Research Supervisor")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/senior_scientist
 	allowed_branches = list(
-		/datum/mil_branch/expeditionary_corps
+		/datum/mil_branch/nanotrasen
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/ec/o1
+		/datum/mil_rank/nt/scientist
 	)
 
 	access = list(
@@ -70,13 +70,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research/scientist
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/solgov,
-		/datum/mil_branch/expeditionary_corps
+		/datum/mil_branch/nanotrasen
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/ec/o1,
 		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/scientist,
-		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/solgov
+		/datum/mil_rank/nt/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/
 	)
 
 	access = list(
@@ -111,14 +109,11 @@
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/research
 	allowed_branches = list(
 		/datum/mil_branch/civilian,
-		/datum/mil_branch/solgov,
-		/datum/mil_branch/expeditionary_corps
+		/datum/mil_branch/nanotrasen
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/ec/e3,
-		/datum/mil_rank/ec/e5,
-		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/assist,
-		/datum/mil_rank/sol/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/assist/solgov
+		/datum/mil_rank/civ/contractor = /decl/hierarchy/outfit/job/torch/passenger/research/scientist,
+		/datum/mil_rank/nt/scientist = /decl/hierarchy/outfit/job/torch/passenger/research/scientist/
 	)
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_DEVICES     = SKILL_MAX,

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -50,6 +50,6 @@
 
 #define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet)
 
-#define CIVILIAN_BRANCHES list(/datum/mil_branch/civilian, /datum/mil_branch/solgov)
+#define CIVILIAN_BRANCHES list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen)
 
 #define SOLGOV_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov)

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -262,6 +262,21 @@
 		/datum/mil_rank/sol/scientist
 	)
 
+/datum/mil_branch/nanotrasen
+	name = "NanoTrasen Employee"
+	name_short = "NT"
+	email_domain = "torch.nt"
+
+	rank_types = list(
+		/datum/mil_rank/nt/rep,
+		/datum/mil_rank/nt/scientist
+	)
+
+	spawn_rank_types = list(
+		/datum/mil_rank/nt/rep,
+		/datum/mil_rank/nt/scientist
+	)
+
 /datum/mil_branch/terran
 	name = "Independent Navy"
 	name_short = "ICCGN"
@@ -679,6 +694,18 @@
 /datum/mil_rank/sol/scientist
 	name = "Government Scientist"
 	name_short = "GOVT"
+	
+/*
+ *  NT Employees
+ *  == =========
+ */
+ 
+ /datum/mil_rank/nt/rep
+	name = "NanoTrasen Representative"
+	name_short = "NTR"
+
+/datum/mil_rank/nt/scientist
+	name = "NanoTrasen Scientist"
 
 /*
  *  Terrans

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -269,12 +269,14 @@
 
 	rank_types = list(
 		/datum/mil_rank/nt/rep,
-		/datum/mil_rank/nt/scientist
+		/datum/mil_rank/nt/scientist,
+		/datum/mil_rank/nt/assetprotection
 	)
 
 	spawn_rank_types = list(
 		/datum/mil_rank/nt/rep,
-		/datum/mil_rank/nt/scientist
+		/datum/mil_rank/nt/scientist,
+		/datum/mil_rank/nt/assetprotection
 	)
 
 /datum/mil_branch/terran

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -708,6 +708,10 @@
 
 /datum/mil_rank/nt/scientist
 	name = "NanoTrasen Scientist"
+	
+/datum/mil_rank/nt/assetprotection
+	name = "Asset Protection"
+	name_short = "APA"
 
 /*
  *  Terrans

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -111,7 +111,7 @@
 /datum/mil_branch/expeditionary_corps
 	name = "Expeditionary Corps"
 	name_short = "SCGEC"
-	email_domain = "torch.ec.scg"
+	email_domain = "solstice.ec.scg"
 
 	rank_types = list(
 		/datum/mil_rank/ec/e3,
@@ -142,7 +142,7 @@
 /datum/mil_branch/fleet
 	name = "Fleet"
 	name_short = "SCGF"
-	email_domain = "torch.fleet.mil"
+	email_domain = "solstice.fleet.mil"
 
 	rank_types = list(
 		/datum/mil_rank/fleet/e1,
@@ -250,7 +250,7 @@
 /datum/mil_branch/solgov
 	name = "SolGov Employee"
 	name_short = "SCG"
-	email_domain = "torch.scg"
+	email_domain = "solstice.scg"
 
 	rank_types = list(
 		/datum/mil_rank/sol/gov,
@@ -267,7 +267,7 @@
 /datum/mil_branch/nanotrasen
 	name = "NanoTrasen Employee"
 	name_short = "NT"
-	email_domain = "torch.nt"
+	email_domain = "solstice.nt"
 
 	rank_types = list(
 		/datum/mil_rank/nt/rep,
@@ -706,13 +706,13 @@
  
  /datum/mil_rank/nt/rep
 	name = "NanoTrasen Representative"
-	name_short = "NTR"
+	name_short = "REP"
 
 /datum/mil_rank/nt/scientist
-	name = "NanoTrasen Scientist"
+	name = "NT Scientist"
 	
 /datum/mil_rank/nt/assetprotection
-	name = "Asset Protection"
+	name = "Asset Protection Agent"
 	name_short = "APA"
 
 /*

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -705,8 +705,7 @@
  */
  
  /datum/mil_rank/nt/rep
-	name = "NanoTrasen Representative"
-	name_short = "REP"
+	name = "NT Rep"
 
 /datum/mil_rank/nt/scientist
 	name = "NT Scientist"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -11,6 +11,7 @@
 		/datum/mil_branch/fleet,
 		/datum/mil_branch/civilian,
 		/datum/mil_branch/solgov,
+		/datum/mil_branch/nanotrasen,
 		/datum/mil_branch/army,
 		/datum/mil_branch/alien,
 		/datum/mil_branch/skrell_fleet
@@ -21,6 +22,7 @@
 		/datum/mil_branch/fleet,
 		/datum/mil_branch/civilian,
 		/datum/mil_branch/solgov,
+		/datum/mil_branch/nanotrasen,
 		/datum/mil_branch/alien,
 		/datum/mil_branch/skrell_fleet
 	)


### PR DESCRIPTION
**Jobs**
- Workplace Liasion is now NanoTrasen Representative
- Executive Assistant is now Asset Protection Agent
- All normal science roles (Assistant and Scientist) are now either Contractor or NT
- Senior Researcher is now only NT
- Chief Science Officer is now only NT

**Other**
- Loadouts have been updated to allow normal NT selection.

**Known Issues**
- NT Representative has "Unknown" for a short name in the job selection screen. It is unknown why it does this despite multiple changes to corporate_jobs and torch_ranks. It doesn't actually seem to affect anything.