### PR TITLE
Military Blacklist

### DIFF
--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -34,25 +34,33 @@
 			/datum/mil_branch/expeditionary_corps,
 			/datum/mil_branch/fleet,
 			/datum/mil_branch/civilian,
+			/datum/mil_branch/nanotrasen,
 			/datum/mil_branch/solgov,
 			/datum/mil_branch/skrell_fleet
 		)
 	)
 
 	species_to_branch_whitelist = list(
-		/datum/species/diona        = list(/datum/mil_branch/civilian),
+		/datum/species/diona        = list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian),
 		/datum/species/nabber       = list(/datum/mil_branch/civilian),
-		/datum/species/skrell       = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/skrell_fleet),
-		/datum/species/unathi       = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
-		/datum/species/unathi/yeosa = list(/datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/skrell       = list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps, /datum/mil_branch/skrell_fleet),
+		/datum/species/unathi       = list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/unathi/yeosa = list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/adherent     = list(/datum/mil_branch/civilian),
-		/datum/species/vox          = list(/datum/mil_branch/alien)
+		/datum/species/vox          = list(/datum/mil_branch/alien),
+		/datum/species/akula		= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/humanathi	= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/sergal		= list(/datum/mil_branch/civilian),
+		/datum/species/tajaran		= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/vasilissan	= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian),
+		/datum/species/vulpkanin	= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 	)
 
 	species_to_rank_blacklist = list(
 		/datum/species/machine = list(
 			/datum/mil_branch/solgov = list(
-				/datum/mil_rank/sol/agent
+				/datum/mil_rank/sol/agent,
+				/datum/mil_rank/sol/gov
 			)
 		)
 	)
@@ -62,19 +70,8 @@
 			/datum/mil_branch/expeditionary_corps = list(
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5,
-				/datum/mil_rank/ec/e7,
-				/datum/mil_rank/ec/o1
+				/datum/mil_rank/ec/e7
 			),
-			/datum/mil_branch/fleet = list(
-				/datum/mil_rank/fleet/e1,
-				/datum/mil_rank/fleet/e2,
-				/datum/mil_rank/fleet/e3,
-				/datum/mil_rank/fleet/e4,
-				/datum/mil_rank/fleet/e5,
-				/datum/mil_rank/fleet/e6,
-				/datum/mil_rank/fleet/e7,
-				/datum/mil_rank/fleet/o1
-			)
 		),
 		/datum/species/skrell = list(
 			/datum/mil_branch/expeditionary_corps = list(
@@ -87,13 +84,39 @@
 		/datum/species/unathi = list(
 			/datum/mil_branch/expeditionary_corps = list(
 				/datum/mil_rank/ec/e3,
-				/datum/mil_rank/ec/e5
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7
 			)
 		),
 		/datum/species/unathi/yeosa = list(
 			/datum/mil_branch/expeditionary_corps = list(
 				/datum/mil_rank/ec/e3,
-				/datum/mil_rank/ec/e5
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7
+			)
+		),
+		/datum/species/unathi/humanathi = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e3,
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7
+			)
+		),
+		/datum/species/tajaran = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e3,
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7
+			)
+		),
+		/datum/species/vulpkanin = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e3,
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7,
+				/datum/mil_rank/ec/o1,
+				/datum/mil_rank/ec/o3,
+				/datum/mil_rank/ec/o5
 			)
 		),
 		/datum/species/vox = list(

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -95,7 +95,7 @@
 				/datum/mil_rank/ec/e7
 			)
 		),
-		/datum/species/unathi/humanathi = list(
+		/datum/species/humanathi = list(
 			/datum/mil_branch/expeditionary_corps = list(
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5,

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -54,6 +54,7 @@
 		/datum/species/tajaran		= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 		/datum/species/vasilissan	= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian),
 		/datum/species/vulpkanin	= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
+		/datum/species/machine		= list(/datum/mil_branch/nanotrasen, /datum/mil_branch/civilian, /datum/mil_branch/expeditionary_corps),
 	)
 
 	species_to_rank_blacklist = list(
@@ -117,6 +118,15 @@
 				/datum/mil_rank/ec/o1,
 				/datum/mil_rank/ec/o3,
 				/datum/mil_rank/ec/o5
+			)
+		),
+		/datum/species/machine = list(
+			/datum/mil_branch/expeditionary_corps = list(
+				/datum/mil_rank/ec/e3,
+				/datum/mil_rank/ec/e5,
+				/datum/mil_rank/ec/e7,
+				/datum/mil_rank/ec/o1,
+				/datum/mil_rank/ec/o3
 			)
 		),
 		/datum/species/vox = list(


### PR DESCRIPTION
Relists the new species.

- Genemodder is open to all.
- Vulp is all NT, including the Rep and CSO. EC up to O-5. No fleet.
- Tajaran is the same for NT. EC up to E-7. No fleet.
- Veteris'Unathi is the same.
- Skrell got a modified whitelist to be NT. NT roles are available. CSO is closed to them.
- Machine is restricted to EC only.
- Diona gets civilian and NT, but no Rep or CSO.
- Unathi and Yeosa'Unathi have the same restrictions as Veteris'Unathi.