### PR TITLE
The Human Xeno

### DIFF
--- a/code/__defines/culture.dm
+++ b/code/__defines/culture.dm
@@ -65,6 +65,7 @@
 #define CULTURE_HUMAN_SPAFRO   "Spacer, Frontier Systems"
 #define CULTURE_HUMAN_CONFED   "Terran"
 #define CULTURE_HUMAN_OTHER    "Other, Humanity"
+#define CULTURE_HUMAN_XENO	   "Humanified Xeno"
 #define CULTURE_STARLIGHT      "Starlit Realms"
 #define CULTURE_MONKEY         "Monkey Business"
 #define CULTURE_FARWA          "Farwa Business"

--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -152,6 +152,23 @@
 		LANGUAGE_SPACER,
 		LANGUAGE_GUTTER,
 		LANGUAGE_SIGN)
+		
+/decl/cultural_info/culture/human/xeno
+	name = CULTURE_HUMAN_XENO
+	description = "There are worlds that the Federation has conquered with native species. The cultural imperialism of the Federation has often replaced the culture of these \
+	once alien worlds. A common joke is that these species were Terraformed. But wherever you came from, your native culture is gone, and you have likely rarely if ever heard \
+	of what it once was. While physically alien, you are culturally Human, and isn't that what ultimately matters?"
+	economic_power = 0.9
+	secondary_langs = list (LANGUAGE_HUMAN_EURO,
+		LANGUAGE_HUMAN_CHINESE,
+		LANGUAGE_HUMAN_ARABIC,
+		LANGUAGE_HUMAN_INDIAN,
+		LANGUAGE_HUMAN_IBERIAN,
+		LANGUAGE_HUMAN_RUSSIAN,
+		LANGUAGE_SPACER,
+		LANGUAGE_GUTTER,
+		LANGUAGE_SIGN)
+	
 
 /decl/cultural_info/culture/human/vatgrown
 	name = CULTURE_HUMAN_VATGROWN

--- a/code/modules/culture_descriptor/faction/factions_human.dm
+++ b/code/modules/culture_descriptor/faction/factions_human.dm
@@ -39,7 +39,7 @@
 /decl/cultural_info/faction/gcc
 	name = FACTION_INDIE_CONFED
 	description = "The Independent Colonial Confederation of Gilgamesh, commonly referred to as the Gilgamesh Colonial Confederation (GCC), is a regional power in human space,\
-	bordered by the Sol Central Government towards the galactic centre. The capital of the Confederation is the city of Ameranth on the planet of Terra \
+	bordered by the Terran Federation towards the galactic centre. The capital of the Confederation is the city of Ameranth on the planet of Terra \
 	in the Gilgamesh system. Externally heavily militant and isolationist, the GCC, internally, is heavily libertarian, with \
 	a strong focus on independent planetary government with the GCC itself only handling defence, foreign relations and some intergalactic trade. \
 	Increasingly anti non-human, the GCC is in a cold war with the Terran Federation following the Great Terran War, a large \
@@ -62,7 +62,7 @@
 
 /decl/cultural_info/faction/police
 	name = FACTION_SPACECOPS
-	description = "The Federal Marshals Service is a government law enforcement agency tasked with enforcing Sol Central Government law, \
+	description = "The Terran Marshals Service is a government law enforcement agency tasked with enforcing Terran Federation law, \
 	investigating breaches of law, fugitive recovery and transport, and securing ports of entry. \
 	Some Agents embedded with other organizations (e.g. an <l>Expeditionary Corps</l> ship) and are expected to answer to their superiors from those organizations. \
 	Notable units are Organized Crime & Vice (self-explanatory), Territory Support (ports of entry and helping local law enforcement), \

--- a/code/modules/culture_descriptor/location/locations_human.dm
+++ b/code/modules/culture_descriptor/location/locations_human.dm
@@ -147,8 +147,8 @@
 	<br><br>The Tersten people are separated into various cultures. For example, urban Tersteners, known as 'Pinascs', live around Tersten City, and are often seen in the defence forces.  \
 	Rural Tersteners, known as 'Nevokies', live in the south central region around the city of Nevada.  Many Martian and Earthling enclaves exist on the planet, significantly in South Harelstone. \
 	The divide between north and south could also be considered a divide between rich and poor. Even the poorest city dweller will likely be richer than most farmers. \
-	Typically untrusting, once a Terstener has made a friend, they will often be that way for life.  Known for their community and attitudes to strangers, they are considered the cowboys of Sol Central. \
-	Many Tersteners serve in the Defence Forces, and many gave their lives in the Gaian Conflict."
+	Typically untrusting, once a Terstener has made a friend, they will often be that way for life.  Known for their community and attitudes to strangers, they are considered the cowboys of the Federation. \
+	Many Tersteners serve in the Defence Forces, and many gave their lives in the Great Terran War."
 	capital = "Tersten City"
 	economic_power = 1.0
 

--- a/modular_solstice/code/modules/species/station/akula.dm
+++ b/modular_solstice/code/modules/species/station/akula.dm
@@ -13,7 +13,8 @@
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick,/datum/unarmed_attack/tail, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp)
 
-	description = "A genemod, divergent from Tritonians by the addition of additional muscle mass and sharper teeth. Though both races are Human-based genemods that arose from the conditions of their aquatic colony-planet, Koster-4, Tritonians have generally always been a more popular choice of genemod, due to an Akula's large dietary needs."
+	description = "Akula are a shark-like species from the planet Koster-4. Predictably, the name of the species was earned due to their appearance. The planet was occupied by \
+	the Terran Federation shortly after discovery. The occupation has been ongoing for centuries, and Akula culture has long since been replaced by human culture."
 
 	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
@@ -22,24 +23,6 @@
 
 
 	available_cultural_info = list( //I can do ANYTHING! Placeholder until the loreboys come and figure out what Akula do | did it - bear
-		TAG_CULTURE = list(
-			CULTURE_HUMAN,
-			CULTURE_HUMAN_VATGROWN,
-			CULTURE_HUMAN_MARTIAN,
-			CULTURE_HUMAN_MARSTUN,
-			CULTURE_HUMAN_LUNAPOOR,
-			CULTURE_HUMAN_LUNARICH,
-			CULTURE_HUMAN_VENUSIAN,
-			CULTURE_HUMAN_VENUSLOW,
-			CULTURE_HUMAN_BELTER,
-			CULTURE_HUMAN_PLUTO,
-			CULTURE_HUMAN_EARTH,
-			CULTURE_HUMAN_CETI,
-			CULTURE_HUMAN_SPACER,
-			CULTURE_HUMAN_SPAFRO,
-			CULTURE_HUMAN_CONFED,
-			CULTURE_SYMBIOTIC,
-			CULTURE_HUMAN_OTHER
-		)
+		TAG_CULTURE = list(CULTURE_HUMAN_XENO)
 	)
 	override_organ_types = list(BP_LUNGS = /obj/item/organ/internal/lungs/gills)

--- a/modular_solstice/code/modules/species/station/akula.dm
+++ b/modular_solstice/code/modules/species/station/akula.dm
@@ -16,7 +16,7 @@
 	description = "Akula are a shark-like species from the planet Koster-4. Predictably, the name of the species was earned due to their appearance. The planet was occupied by \
 	the Terran Federation shortly after discovery. The occupation has been ongoing for centuries, and Akula culture has long since been replaced by human culture."
 
-	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_IS_ICONBASE
+	spawn_flags = SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	sexybits_location = BP_GROIN //this is possibly my favorite variable just because of how out of place it is.

--- a/modular_solstice/code/modules/species/station/akula.dm
+++ b/modular_solstice/code/modules/species/station/akula.dm
@@ -16,7 +16,7 @@
 	description = "Akula are a shark-like species from the planet Koster-4. Predictably, the name of the species was earned due to their appearance. The planet was occupied by \
 	the Terran Federation shortly after discovery. The occupation has been ongoing for centuries, and Akula culture has long since been replaced by human culture."
 
-	spawn_flags = SPECIES_IS_ICONBASE
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	sexybits_location = BP_GROIN //this is possibly my favorite variable just because of how out of place it is.

--- a/modular_solstice/code/modules/species/station/tajaran.dm
+++ b/modular_solstice/code/modules/species/station/tajaran.dm
@@ -19,7 +19,7 @@
 	While reaching to the stars independently from outside influences, the humans engaged them in peaceful trade contact \
 	and have accelerated the fledgling culture into the interstellar age. Their history is full of war and highly fractious \
 	governments, something that permeates even to today's times. They prefer colder, tundra-like climates, much like their \
-	home worlds and speak a variety of languages, especially Siik and Akhani."
+	home worlds."
 
 	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
@@ -28,29 +28,7 @@
 
 
 	available_cultural_info = list( //I can do ANYTHING! Placeholder until the loreboys come and figure out what Tajara do
-		TAG_CULTURE = list(
-			CULTURE_HUMAN,
-			CULTURE_HUMAN_VATGROWN,
-			CULTURE_HUMAN_MARTIAN,
-			CULTURE_HUMAN_MARSTUN,
-			CULTURE_HUMAN_LUNAPOOR,
-			CULTURE_HUMAN_LUNARICH,
-			CULTURE_HUMAN_VENUSIAN,
-			CULTURE_HUMAN_VENUSLOW,
-			CULTURE_HUMAN_BELTER,
-			CULTURE_HUMAN_PLUTO,
-			CULTURE_HUMAN_EARTH,
-			CULTURE_HUMAN_CETI,
-			CULTURE_HUMAN_SPACER,
-			CULTURE_HUMAN_SPAFRO,
-			CULTURE_HUMAN_CONFED,
-			CULTURE_HUMAN_OTHER,
-			CULTURE_SKRELL_QERR,
-			CULTURE_SKRELL_MALISH,
-			CULTURE_SKRELL_KANIN,
-			CULTURE_SKRELL_TALUM,
-			CULTURE_SKRELL_RASKINTA,
-			)
+		TAG_CULTURE = list(CULTURE_HUMAN_XENO)
 	)
 
 /datum/species/tajaran/proc/handle_coco(var/mob/living/carbon/human/M, var/datum/reagent/nutriment/coco, var/efficiency = 1)

--- a/modular_solstice/code/modules/species/station/vasilissan.dm
+++ b/modular_solstice/code/modules/species/station/vasilissan.dm
@@ -17,7 +17,7 @@
 	discovered. This was due to already being in the atomic era when they were found by the now-defunct NanoTrasen Surveyor Corps. They've integrated rather well \
 	into interstellar society, with only a few hiccups in political relations, mostly involving the fact they are spiders."
 
-	spawn_flags = SPECIES_IS_ICONBASE
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	sexybits_location = BP_GROIN //this is possibly my favorite variable just because of how out of place it is. - cebu | what the hell does it even do -tori | Basically it just defines where you can hit them for massive (pain) damage. An entire variable dedicated to nutshots. -cebu  | do these guys even have junk in their groin??? -cebu

--- a/modular_solstice/code/modules/species/station/vasilissan.dm
+++ b/modular_solstice/code/modules/species/station/vasilissan.dm
@@ -17,7 +17,7 @@
 	discovered. This was due to already being in the atomic era when they were found by the now-defunct NanoTrasen Surveyor Corps. They've integrated rather well \
 	into interstellar society, with only a few hiccups in political relations, mostly involving the fact they are spiders."
 
-	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_IS_ICONBASE
+	spawn_flags = SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	sexybits_location = BP_GROIN //this is possibly my favorite variable just because of how out of place it is. - cebu | what the hell does it even do -tori | Basically it just defines where you can hit them for massive (pain) damage. An entire variable dedicated to nutshots. -cebu  | do these guys even have junk in their groin??? -cebu

--- a/modular_solstice/code/modules/species/station/vasilissan.dm
+++ b/modular_solstice/code/modules/species/station/vasilissan.dm
@@ -13,7 +13,9 @@
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/claws)
 
-	description = "Vasilissans are a race of enlightened, spider-like people. They have the distinction of being one of the only races that was spared from a war upon being discovered. This was due to already being in the atomic era when they were found by the now-defunct NanoTrasen Surveyor Corps. They've integrated rather well into interstellar society, with only a few hiccups in political relations, mostly involving the fact they are spiders."
+	description = "Vasilissans are a race of spider-like people. They have the distinction of being one of the only races that was spared from a war upon being \
+	discovered. This was due to already being in the atomic era when they were found by the now-defunct NanoTrasen Surveyor Corps. They've integrated rather well \
+	into interstellar society, with only a few hiccups in political relations, mostly involving the fact they are spiders."
 
 	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
@@ -22,23 +24,5 @@
 
 
 	available_cultural_info = list( //I can do ANYTHING! Placeholder until the loreboys come and figure out what Vasilissans do | did it -bear
-		TAG_CULTURE = list(
-			CULTURE_HUMAN,
-			CULTURE_HUMAN_VATGROWN,
-			CULTURE_HUMAN_MARTIAN,
-			CULTURE_HUMAN_MARSTUN,
-			CULTURE_HUMAN_LUNAPOOR,
-			CULTURE_HUMAN_LUNARICH,
-			CULTURE_HUMAN_VENUSIAN,
-			CULTURE_HUMAN_VENUSLOW,
-			CULTURE_HUMAN_BELTER,
-			CULTURE_HUMAN_PLUTO,
-			CULTURE_HUMAN_EARTH,
-			CULTURE_HUMAN_CETI,
-			CULTURE_HUMAN_SPACER,
-			CULTURE_HUMAN_SPAFRO,
-			CULTURE_HUMAN_CONFED,
-			CULTURE_HUMAN_OTHER,
-			CULTURE_SYMBIOTIC
-		)
+		TAG_CULTURE = list(CULTURE_HUMAN_XENO)
 	)

--- a/modular_solstice/code/modules/species/station/vulpkanin.dm
+++ b/modular_solstice/code/modules/species/station/vulpkanin.dm
@@ -18,7 +18,7 @@
 	ago. Since discovery, they've been occupied by the Terran Federation. Over those centuries, their old culture is indistinguishable from Terran culture, and their past \
 	and cultural traditions are largely forgotten."
 
-	spawn_flags = SPECIES_CAN_JOIN /*SPECIES_IS_RESTRICTED --why?*/ | SPECIES_IS_ICONBASE
+	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
 
 	sexybits_location = BP_GROIN //this is possibly my favorite variable just because of how out of place it is. - cebu | what the hell does it even do -tori | Basically it just defines where you can hit them for massive (pain) damage. An entire variable dedicated to nutshots. -cebu

--- a/modular_solstice/code/modules/species/station/vulpkanin.dm
+++ b/modular_solstice/code/modules/species/station/vulpkanin.dm
@@ -14,7 +14,9 @@
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/claws)
 
-	description = "Vulpkanin is a catch-all term for all sorts of canid-like genemods. Vulpkanin genemods, initially patented by VeyMed, were made popular about the middle of the 22nd century, and have only increased in number since. It's such a prolific type of genemod that there are entire communities of naturally-reproducing, self-sustaining populations. You could be from anywhere- Sol space, or the Frontier, or maybe even the UCG, and look down upon others, knowing you are intelligently designed."
+	description = "Vulpkanin are another of the animal-like races the Federation has discovered over the years. They were first discovered by NanoTrasen explorers centuries \
+	ago. Since discovery, they've been occupied by the Terran Federation. Over those centuries, their old culture is indistinguishable from Terran culture, and their past \
+	and cultural traditions are largely forgotten."
 
 	spawn_flags = SPECIES_CAN_JOIN /*SPECIES_IS_RESTRICTED --why?*/ | SPECIES_IS_ICONBASE
 	appearance_flags = HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_SKIN_COLOR | HAS_EYE_COLOR
@@ -23,25 +25,7 @@
 
 
 	available_cultural_info = list( //I can do ANYTHING! Placeholder until the loreboys come and figure out what Vulpkanin do | did it -bear
-		TAG_CULTURE = list(
-			CULTURE_HUMAN,
-			CULTURE_HUMAN_VATGROWN,
-			CULTURE_HUMAN_MARTIAN,
-			CULTURE_HUMAN_MARSTUN,
-			CULTURE_HUMAN_LUNAPOOR,
-			CULTURE_HUMAN_LUNARICH,
-			CULTURE_HUMAN_VENUSIAN,
-			CULTURE_HUMAN_VENUSLOW,
-			CULTURE_HUMAN_BELTER,
-			CULTURE_HUMAN_PLUTO,
-			CULTURE_HUMAN_EARTH,
-			CULTURE_HUMAN_CETI,
-			CULTURE_HUMAN_SPACER,
-			CULTURE_HUMAN_SPAFRO,
-			CULTURE_HUMAN_CONFED,
-			CULTURE_HUMAN_OTHER,
-			CULTURE_SYMBIOTIC
-		)
+		TAG_CULTURE = list(CULTURE_HUMAN_XENO)
 	)
 
 /datum/species/vulpkanin/proc/handle_coco(var/mob/living/carbon/human/M, var/datum/reagent/nutriment/coco, var/efficiency = 1)


### PR DESCRIPTION
- A few more Federation renames
- Adds HUMAN_XENO culture for future use, to reflect lore
- Applies culture to Tajara, Akula, Vulpkanin, and the spider people
- Makes Akula and spider people playable