### PR TITLE
Army Implementation Part Two

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -12,7 +12,7 @@
 	var/armycover = list()
 	armycover = /obj/item/clothing/head/solgov/utility/army/urban
 	armycover = /obj/item/clothing/head/solgov/utility/army/navy
-	gear_tweaks += new/datum/gear_tweak/path(armycover)
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(armycover)
 
 /datum/gear/head/beret
 	display_name = "beret, colour select"

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -3,6 +3,17 @@
 	slot = slot_head
 	category = /datum/gear/head
 
+/datum/gear/head/armycover
+	display_name = "army cover selection"
+	path = /obj/item/clothing/head/solgov/utility/army/
+	
+/datum/gear/head/armycover/New()
+	..()
+	var/armycover = list()
+	armycover = /obj/item/clothing/head/solgov/utility/army/urban
+	armycover = /obj/item/clothing/head/solgov/utility/army/navy
+	gear_tweaks += new/datum/gear_tweak/path(armycover)
+
 /datum/gear/head/beret
 	display_name = "beret, colour select"
 	path = /obj/item/clothing/head/beret/plaincolor

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -10,8 +10,8 @@
 /datum/gear/head/armycover/New()
 	..()
 	var/armycover = list()
-	armycover = /obj/item/clothing/head/solgov/utility/army/urban
-	armycover = /obj/item/clothing/head/solgov/utility/army/navy
+	armycover += /obj/item/clothing/head/solgov/utility/army/urban
+	armycover += /obj/item/clothing/head/solgov/utility/army/navy
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(armycover)
 
 /datum/gear/head/beret

--- a/code/modules/client/preference_setup/loadout/lists/tactical.dm
+++ b/code/modules/client/preference_setup/loadout/lists/tactical.dm
@@ -7,6 +7,32 @@
 	display_name = "armor customization"
 	path = /obj/item/clothing/accessory/armor/tag
 	flags = GEAR_HAS_SUBTYPE_SELECTION
+	
+/datum/gear/tactical/solgov
+	display_name = "Federation Flag tag"
+	path = /obj/item/clothing/accessory/armor/tag/solgov
+	allowed_branches = SOLGOV_BRANCHES
+	cost = 0 // Uniformed branches would require one.
+	
+// Separating main's certain armor customization items.
+/datum/gear/tactical/blood_patch
+	display_name = "blood patch selection"
+	description = "A selection of blood type patches. Attaches to plate carrier."
+	path = /obj/item/clothing/accessory/armor/tag/
+	cost = 0 // Life-saving.
+
+/datum/gear/tactical/blood_patch/New()
+	..()
+	var/blood_type = list()
+	blood_type["A+"] = /obj/item/clothing/accessory/armor/tag/apos
+	blood_type["A-"] = /obj/item/clothing/accessory/armor/tag/aneg
+	blood_type["B+"] = /obj/item/clothing/accessory/armor/tag/bpos
+	blood_type["B-"] = /obj/item/clothing/accessory/armor/tag/bneg
+	blood_type["AB+"] = /obj/item/clothing/accessory/armor/tag/abpos
+	blood_type["AB-"] = /obj/item/clothing/accessory/armor/tag/abneg
+	blood_type["O+"] = /obj/item/clothing/accessory/armor/tag/opos
+	blood_type["O-"] = /obj/item/clothing/accessory/armor/tag/oneg
+	gear_tweaks += new/datum/gear_tweak/path(blood_type)
 
 /datum/gear/tactical/helm_covers
 	display_name = "helmet covers"

--- a/code/modules/client/preference_setup/loadout/lists/tactical.dm
+++ b/code/modules/client/preference_setup/loadout/lists/tactical.dm
@@ -11,7 +11,7 @@
 /datum/gear/tactical/solgov
 	display_name = "Federation Flag tag"
 	path = /obj/item/clothing/accessory/armor/tag/solgov
-	allowed_branches = SOLGOV_BRANCHES
+	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/army, /datum/mil_branch/expeditionary_corps)
 	cost = 0 // Uniformed branches would require one.
 	
 // Separating main's certain armor customization items.

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -11,7 +11,7 @@
 	display_name = "army fatigues selection"
 	path = /obj/item/clothing/under/solgov/utility/army
 	
-/datum/gear/uniform/dress/New()
+/datum/gear/uniform/armyfatigues/New()
 	..()
 	var/armyfatigues = list()
 	armyfatigues += /obj/item/clothing/under/solgov/utility/army/urban

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -6,6 +6,17 @@
 /datum/gear/uniform/fleetfatigues
 	display_name = "navy fatigues"
 	path = /obj/item/clothing/under/solgov/utility/fleet/combat
+	
+/datum/gear/uniform/armyfatigues
+	display_name = "army fatigues selection"
+	path = /obj/item/clothing/under/solgov/utility/army
+	
+/datum/gear/uniform/dress/New()
+	..()
+	var/armyfatigues = list()
+	armyfatigues += /obj/item/clothing/under/solgov/utility/army/urban
+	armyfatigues += /obj/item/clothing/under/solgov/utility/army/navy
+	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(armyfatigues)
 
 /datum/gear/uniform/jumpsuit
 	display_name = "jumpsuit, colour select"

--- a/maps/torch/datums/uniforms_army.dm
+++ b/maps/torch/datums/uniforms_army.dm
@@ -1,6 +1,8 @@
 /decl/hierarchy/mil_uniform
+	var/utility_under_navy = null
 	var/utility_under_urban = null
 	var/utility_under_tan = null
+	var/utility_hat_navy = null
 	var/utility_hat_urban = null
 	var/utility_hat_tan = null
 

--- a/maps/torch/datums/uniforms_army.dm
+++ b/maps/torch/datums/uniforms_army.dm
@@ -12,10 +12,10 @@
 	pt_under = /obj/item/clothing/under/solgov/pt/army
 	pt_shoes = /obj/item/clothing/shoes/black
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
 	utility_shoes = /obj/item/clothing/shoes/dutyboots
-	utility_hat = /obj/item/clothing/head/solgov/utility/army
+	utility_hat_navy = /obj/item/clothing/head/solgov/utility/army/navy
 	utility_hat_urban = /obj/item/clothing/head/solgov/utility/army/urban
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
@@ -45,7 +45,7 @@
 	name = "Army command"
 	departments = COM
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
@@ -75,7 +75,7 @@
 	name = "Army engineering"
 	departments = ENG
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/engineering
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/engineering
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/engineering
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
@@ -134,7 +134,7 @@
 	name = "Army security"
 	departments = SEC
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/security
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/security
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/security
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
@@ -193,7 +193,7 @@
 	name = "Army medical"
 	departments = MED
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/medical
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/medical
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/medical
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -251,7 +251,7 @@
 	name = "Army supply"
 	departments = SUP
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/supply
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/supply
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/supply
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -307,7 +307,7 @@
 		/obj/item/clothing/head/soft/solgov
 	)
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
@@ -321,7 +321,7 @@
 	name = "Army service"
 	departments = SRV
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/service
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/service
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/service
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -368,7 +368,7 @@
 	name = "Army exploration"
 	departments = EXP
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/exploration
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/exploration
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/exploration
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -415,7 +415,7 @@
 	name = "Army command support"
 	departments = SPT
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 /decl/hierarchy/mil_uniform/army/spt/noncom
@@ -443,7 +443,7 @@
 		/obj/item/clothing/gloves/thick/duty/solgov/cmd
 	)
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
@@ -468,7 +468,7 @@
 		/obj/item/clothing/gloves/thick/duty/solgov/cmd
 	)
 
-	utility_under = /obj/item/clothing/under/solgov/utility/army/command
+	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command

--- a/maps/torch/datums/uniforms_army.dm
+++ b/maps/torch/datums/uniforms_army.dm
@@ -18,7 +18,7 @@
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy
 	utility_shoes = /obj/item/clothing/shoes/dutyboots
 	utility_hat_navy = /obj/item/clothing/head/solgov/utility/army/navy
-	utility_hat_urban = /obj/item/clothing/head/solgov/utility/army/urban
+	utility_hat = /obj/item/clothing/head/solgov/utility/army/urban
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,

--- a/maps/torch/datums/uniforms_army.dm
+++ b/maps/torch/datums/uniforms_army.dm
@@ -46,7 +46,7 @@
 	departments = COM
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
 		/obj/item/clothing/head/beret/solgov,
@@ -76,7 +76,7 @@
 	departments = ENG
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/engineering
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/engineering
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -135,7 +135,7 @@
 	departments = SEC
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/security
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/security
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -194,7 +194,7 @@
 	departments = MED
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/medical
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/medical
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -252,7 +252,7 @@
 	departments = SUP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/supply
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/supply
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -322,7 +322,7 @@
 	departments = SRV
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/service
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/service
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -369,7 +369,7 @@
 	departments = EXP
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/exploration
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/exploration
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -416,7 +416,7 @@
 	departments = SPT
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 /decl/hierarchy/mil_uniform/army/spt/noncom
 	name = "Army support NCO"
@@ -444,7 +444,7 @@
 	)
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
@@ -469,7 +469,7 @@
 	)
 
 	utility_under = /obj/item/clothing/under/solgov/utility/army/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
+	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command

--- a/maps/torch/datums/uniforms_army.dm
+++ b/maps/torch/datums/uniforms_army.dm
@@ -20,11 +20,8 @@
 	utility_hat_navy = /obj/item/clothing/head/solgov/utility/army/navy
 	utility_hat = /obj/item/clothing/head/solgov/utility/army/urban
 	utility_extra = list(
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov
+		/obj/item/clothing/under/solgov/utility/army/navy/,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 	)
 
 	service_under = /obj/item/clothing/under/solgov/service/army
@@ -47,14 +44,10 @@
 	name = "Army command"
 	departments = COM
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/command,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/cmd
 	)
 
@@ -77,20 +70,22 @@
 	name = "Army engineering"
 	departments = ENG
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/engineering
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/engineering
 	utility_extra = list(
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/engineering,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/eng
 	)
 
 /decl/hierarchy/mil_uniform/army/eng/noncom
 	name = "Army engineering NCO"
 	min_rank = 4
+
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/navy/engineering,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/eng
+	)
 
 	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
@@ -104,12 +99,8 @@
 	min_rank = 11
 
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/engineering,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/eng
 	)
 
@@ -136,20 +127,22 @@
 	name = "Army security"
 	departments = SEC
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/security
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/security
 	utility_extra = list(
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
-		/obj/item/clothing/gloves/thick/duty/solgov/sec,
-		/obj/item/clothing/under/solgov/utility/army/security)
+		/obj/item/clothing/under/solgov/utility/army/navy/security,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/sec
+	)
 
 /decl/hierarchy/mil_uniform/army/sec/noncom
 	name = "Army security NCO"
 	min_rank = 4
+	
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/navy/security,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/med
+	)
 
 	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
@@ -163,12 +156,8 @@
 	min_rank = 11
 
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/security,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/sec
 	)
 
@@ -195,19 +184,22 @@
 	name = "Army medical"
 	departments = MED
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/medical
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/medical
 	utility_extra = list(
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/medical,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/med
 	)
 
 /decl/hierarchy/mil_uniform/army/med/noncom
 	name = "Army medical NCO"
 	min_rank = 4
+	
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/navy/medical,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/med
+	)
 
 	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
@@ -221,12 +213,8 @@
 	min_rank = 11
 
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/medical,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/med
 	)
 
@@ -253,19 +241,23 @@
 	name = "Army supply"
 	departments = SUP
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/supply
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/supply
 	utility_extra = list(
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/supply,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/sup
 	)
 
 /decl/hierarchy/mil_uniform/army/sup/noncom
 	name = "Army supply NCO"
 	min_rank = 4
+	
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/supply	
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/navy/supply,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/sup
+	)
 
 	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
@@ -278,13 +270,10 @@
 	name = "Army supply CO"
 	min_rank = 11
 
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/supply
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/supply,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/sup
 	)
 
@@ -300,16 +289,12 @@
 	name = "Army supply senior command"
 	min_rank = 15
 
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/supply
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov
+		/obj/item/clothing/under/solgov/utility/army/navy/supply,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/sup
 	)
-
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
@@ -323,19 +308,23 @@
 	name = "Army service"
 	departments = SRV
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/service
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/service
 	utility_extra = list(
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/service,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/svc
 	)
 
 /decl/hierarchy/mil_uniform/army/srv/noncom
 	name = "Army service NCO"
 	min_rank = 4
+
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/service
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/navy/service,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/svc
+	)
 
 	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
@@ -348,13 +337,10 @@
 	name = "Army service CO"
 	min_rank = 11
 
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/service
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/service,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/svc
 	)
 
@@ -370,19 +356,23 @@
 	name = "Army exploration"
 	departments = EXP
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/exploration
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/exploration
 	utility_extra = list(
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/exploration,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/exp
 	)
 
 /decl/hierarchy/mil_uniform/army/exp/noncom
 	name = "Army exploration NCO"
 	min_rank = 4
+
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/exploration
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/navy/exploration,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/exp
+	)
 
 	service_hat = /obj/item/clothing/head/solgov/service/army
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army
@@ -395,13 +385,10 @@
 	name = "Army exploration CO"
 	min_rank = 11
 
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/exploration
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/exploration,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/exp
 	)
 
@@ -417,8 +404,12 @@
 	name = "Army command support"
 	departments = SPT
 
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
 	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_extra = list(
+		/obj/item/clothing/under/solgov/utility/army/navy/command,
+		/obj/item/clothing/head/solgov/utility/army/navy,
+		/obj/item/clothing/gloves/thick/duty/solgov/cmd
+	)
 
 /decl/hierarchy/mil_uniform/army/spt/noncom
 	name = "Army support NCO"
@@ -435,18 +426,12 @@
 	name = "Army command support CO"
 	min_rank = 11
 
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/command,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/cmd
 	)
-
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
-	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
@@ -460,18 +445,12 @@
 	name = "Army senior command support"
 	min_rank = 15
 
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 	utility_extra = list(
-		/obj/item/clothing/under/solgov/utility/army/command,
-		/obj/item/clothing/head/beret/solgov,
-		/obj/item/clothing/head/ushanka/solgov/army,
-		/obj/item/clothing/head/ushanka/solgov/army/green,
-		/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
-		/obj/item/clothing/head/soft/solgov,
+		/obj/item/clothing/under/solgov/utility/army/navy/command,
+		/obj/item/clothing/head/solgov/utility/army/navy,
 		/obj/item/clothing/gloves/thick/duty/solgov/cmd
 	)
-
-	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
-	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command

--- a/maps/torch/datums/uniforms_army.dm
+++ b/maps/torch/datums/uniforms_army.dm
@@ -14,8 +14,8 @@
 	pt_under = /obj/item/clothing/under/solgov/pt/army
 	pt_shoes = /obj/item/clothing/shoes/black
 
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban
 	utility_shoes = /obj/item/clothing/shoes/dutyboots
 	utility_hat_navy = /obj/item/clothing/head/solgov/utility/army/navy
 	utility_hat_urban = /obj/item/clothing/head/solgov/utility/army/urban
@@ -48,7 +48,7 @@
 	departments = COM
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 	utility_extra = list(
 		/obj/item/clothing/under/solgov/utility/army/command,
 		/obj/item/clothing/head/beret/solgov,
@@ -78,7 +78,7 @@
 	departments = ENG
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/engineering
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/engineering
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/engineering
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -137,7 +137,7 @@
 	departments = SEC
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/security
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/security
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/security
 	utility_extra = list(
 		/obj/item/clothing/head/beret/solgov,
 		/obj/item/clothing/head/ushanka/solgov/army,
@@ -196,7 +196,7 @@
 	departments = MED
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/medical
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/medical
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/medical
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -254,7 +254,7 @@
 	departments = SUP
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/supply
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/supply
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/supply
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -324,7 +324,7 @@
 	departments = SRV
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/service
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/service
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/service
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -371,7 +371,7 @@
 	departments = EXP
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/exploration
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/exploration
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/exploration
 	utility_extra = list(
 		/obj/item/clothing/head/ushanka/solgov/army,
 		/obj/item/clothing/head/ushanka/solgov/army/green,
@@ -418,7 +418,7 @@
 	departments = SPT
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 /decl/hierarchy/mil_uniform/army/spt/noncom
 	name = "Army support NCO"
@@ -446,7 +446,7 @@
 	)
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command
@@ -471,7 +471,7 @@
 	)
 
 	utility_under_navy = /obj/item/clothing/under/solgov/utility/army/navy/command
-	utility_under_urban = /obj/item/clothing/under/solgov/utility/army/urban/command
+	utility_under = /obj/item/clothing/under/solgov/utility/army/urban/command
 
 	service_hat = /obj/item/clothing/head/solgov/service/army/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/army/command

--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -64,6 +64,11 @@
 	name = "urban utility cover"
 	desc = "A grey utility cover bearing the crest of the Terran Army."
 	icon_state = "greyutility"
+	
+/obj/item/clothing/head/solgov/utility/army/navy
+	name = "navy utility cover"
+	desc = "A navy blue utility cover bearing the crest of the Terran Army."
+	icon_state = "navyutility"
 
 //Service
 

--- a/maps/torch/items/clothing/solgov-under.dm
+++ b/maps/torch/items/clothing/solgov-under.dm
@@ -266,12 +266,90 @@
 	item_state = "gy_suit"
 	worn_state = "greyutility"
 
+/obj/item/clothing/under/solgov/utility/army/urban/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/engineering
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/security
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/medical
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/medical/banded
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army, /obj/item/clothing/accessory/armband/medblue)
+
+/obj/item/clothing/under/solgov/utility/army/urban/supply
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/service
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/service/army)
+
+/obj/item/clothing/under/solgov/utility/army/urban/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/army)
+
 /obj/item/clothing/under/solgov/utility/army/tan
 	name = "tan fatigues"
 	desc = "A tan version of the Terran Army utility uniform, made from durable material."
 	icon_state = "tanutility"
 	item_state = "johnny"
 	worn_state = "tanutility"
+	
+/obj/item/clothing/under/solgov/utility/army/tan/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/engineering
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/security
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/medical
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/medical/banded
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army, /obj/item/clothing/accessory/armband/medblue)
+
+/obj/item/clothing/under/solgov/utility/army/tan/supply
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/service
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/service/army)
+
+/obj/item/clothing/under/solgov/utility/army/tan/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/army)
+	
+/obj/item/clothing/under/solgov/utility/army/navy
+	name = "navy fatigues"
+	desc = "Alternative utility uniform of the Terran Army, designed for ship use."
+	icon_state = "navycombat"
+	worn_state = "navycombat"
+	
+/obj/item/clothing/under/solgov/utility/army/navy/command
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/command/army)
+
+/obj/item/clothing/under/solgov/utility/army/navy/engineering
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/engineering/army)
+
+/obj/item/clothing/under/solgov/utility/army/navy/security
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/security/army)
+
+/obj/item/clothing/under/solgov/utility/army/navy/medical
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army)
+
+/obj/item/clothing/under/solgov/utility/army/navy/medical/banded
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/medical/army, /obj/item/clothing/accessory/armband/medblue)
+
+/obj/item/clothing/under/solgov/utility/army/navy/supply
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/supply/army)
+
+/obj/item/clothing/under/solgov/utility/army/navy/service
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/service/army)
+
+/obj/item/clothing/under/solgov/utility/army/navy/exploration
+	starting_accessories = list(/obj/item/clothing/accessory/solgov/department/exploration/army)
 
 //Service
 

--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -120,6 +120,14 @@
 	id_types = list(/obj/item/weapon/card/id/torch/crew/sea)
 	pda_type = /obj/item/modular_computer/pda/heads
 
+/decl/hierarchy/outfit/job/torch/crew/command/sea/army
+	name = OUTFIT_JOB_NAME("Senior Enlisted Advisor - Army")
+	uniform = /obj/item/clothing/under/solgov/utility/army/urban/command
+	shoes = /obj/item/clothing/shoes/dutyboots
+	l_ear = /obj/item/device/radio/headset/sea
+	id_types = list(/obj/item/weapon/card/id/torch/crew/sea)
+	pda_type = /obj/item/modular_computer/pda/heads
+
 /decl/hierarchy/outfit/job/torch/crew/command/bridgeofficer
 	name = OUTFIT_JOB_NAME("Bridge Officer")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/officer/command

--- a/maps/torch/job/outfits/security_outfits.dm
+++ b/maps/torch/job/outfits/security_outfits.dm
@@ -21,7 +21,7 @@
 	
 /decl/hierarchy/outfit/job/torch/crew/security/brig_chief/army
 	name = OUTFIT_JOB_NAME("Brig Chief - Army")
-	uniform = /obj/item/clothing/under/solgov/utility/army/security
+	uniform = /obj/item/clothing/under/solgov/utility/army/urban/security
 	shoes = /obj/item/clothing/shoes/dutyboots
 
 /decl/hierarchy/outfit/job/torch/crew/security/forensic_tech
@@ -62,5 +62,5 @@
 
 /decl/hierarchy/outfit/job/torch/crew/security/maa/army
 	name = OUTFIT_JOB_NAME("Master at Arms - Army")
-	uniform = /obj/item/clothing/under/solgov/utility/army/security
+	uniform = /obj/item/clothing/under/solgov/utility/army/urban/security
 	shoes = /obj/item/clothing/shoes/dutyboots

--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -48,8 +48,8 @@
 //For jobs that spawn with armor in their lockers
 #define ARMORED_ROLES list(/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/qm, /datum/job/sea, /datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/merchant, /datum/job/submap/skrellscoutship_crew, /datum/job/submap/skrellscoutship_crew/leader, /datum/job/submap/scavver_pilot, /datum/job/submap/scavver_doctor, /datum/job/submap/scavver_engineer)
 
-#define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet)
+#define UNIFORMED_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/army)
 
 #define CIVILIAN_BRANCHES list(/datum/mil_branch/civilian, /datum/mil_branch/solgov, /datum/mil_branch/nanotrasen)
 
-#define SOLGOV_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/solgov)
+#define SOLGOV_BRANCHES list(/datum/mil_branch/expeditionary_corps, /datum/mil_branch/fleet, /datum/mil_branch/army, /datum/mil_branch/solgov)

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -235,7 +235,7 @@
 /datum/gear/tactical/armor_pouches/navy
 	display_name = "navy armor pouches"
 	path = /obj/item/clothing/accessory/storage/pouches/navy
-	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/civilian)
+	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/army, /datum/mil_branch/civilian)
 
 /datum/gear/tactical/armor_pouches/misc
 	display_name = "miscellaneous armor pouches selection"
@@ -258,7 +258,7 @@
 /datum/gear/tactical/large_pouches/navy
 	display_name = "navy large armor pouches"
 	path = /obj/item/clothing/accessory/storage/pouches/large/navy
-	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/civilian)
+	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/army, /datum/mil_branch/civilian)
 
 /datum/gear/tactical/large_pouches/misc
 	display_name = "miscellaneous large armor pouches selection"

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -32,6 +32,19 @@
 	path = /obj/item/clothing/head/solgov/utility/fleet
 	cost = 0
 	allowed_branches = list(/datum/mil_branch/fleet)
+	
+/datum/gear/head/armycover
+	display_name = "utilty cover selection"
+	path = /obj/item/clothing/head/solgov/utility/army/
+	cost = 0
+	allowed_branches = list(/datum/mil_branch/army)
+	
+/datum/gear/head/armycover/New()
+	..()
+	var/armycover = list()
+	armycover = /obj/item/clothing/head/solgov/utility/army/urban
+	armycover = /obj/item/clothing/head/solgov/utility/army/navy
+	gear_tweaks += new/datum/gear_tweak/path(armycover)
 
 /datum/gear/head/fleetcap
 	display_name = "fleet cap"

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -34,17 +34,8 @@
 	allowed_branches = list(/datum/mil_branch/fleet)
 	
 /datum/gear/head/armycover
-	display_name = "utilty cover selection"
-	path = /obj/item/clothing/head/solgov/utility/army/
-	cost = 0
 	allowed_branches = list(/datum/mil_branch/army)
-	
-/datum/gear/head/armycover/New()
-	..()
-	var/armycover = list()
-	armycover = /obj/item/clothing/head/solgov/utility/army/urban
-	armycover = /obj/item/clothing/head/solgov/utility/army/navy
-	gear_tweaks += new/datum/gear_tweak/path(armycover)
+	cost = 0
 
 /datum/gear/head/fleetcap
 	display_name = "fleet cap"

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -104,7 +104,7 @@
 /datum/gear/tactical/pcarrier/navy
 	display_name = "navy blue plate carrier"
 	path = /obj/item/clothing/suit/armor/pcarrier/navy
-	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/civilian)
+	allowed_branches = list(/datum/mil_branch/fleet, /datum/mil_branch/army, /datum/mil_branch/civilian)
 
 /datum/gear/tactical/pcarrier/misc
 	display_name = "miscellaneous plate carrier selection"
@@ -119,7 +119,7 @@
 	gear_tweaks += new/datum/gear_tweak/path(armors)
 
 /datum/gear/suit/sfp
-	display_name = "Agent's jacket"
+	display_name = "marshal's jacket"
 	path = /obj/item/clothing/suit/storage/toggle/agent_jacket
 	allowed_roles = list(/datum/job/detective)
 	allowed_branches = list(/datum/mil_branch/solgov)

--- a/maps/torch/loadout/loadout_uniform.dm
+++ b/maps/torch/loadout/loadout_uniform.dm
@@ -4,6 +4,11 @@
 	
 /datum/gear/uniform/fleetfatigues
 	allowed_branches = list(/datum/mil_branch/fleet)
+	cost = 0
+	
+/datum/gear/uniform/armyfatigues
+	allowed_branches = list(/datum/mil_branch/army)
+	cost = 0
 
 /datum/gear/uniform/utility
 	display_name = "Contractor Utility Uniform"


### PR DESCRIPTION
**Assorted Fixes**
- Uniform vendors now properly dispense urban and navy colored Army uniforms
- Urban uniforms are the primary uniform
- All non-green uniforms have a colored department tag option (though it may be changed to the navy style, as army style is hard to see)

**Loadout Changes:**
- Blood patches are now separated from customization and free
- For military and armored roles (security/command mainly), the Federation flag patch is free
- Army should be able to select navy plate carriers, should they use the blue uniform instead of black