### PR TITLE
Removes debug text printing out to admins, adds an option to see curr…

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -30,7 +30,6 @@ SUBSYSTEM_DEF(jobs)
 
 	for(var/jtype in subtypesof(/datum/job))
 		var/datum/job/job = jtype
-		report_progress("aaa '[job]' '' '[initial(job.title)]'")
 		all_jobs += initial(job.title)
 
 	// Create main map jobs.

--- a/code/modules/client/border_control.dm
+++ b/code/modules/client/border_control.dm
@@ -7,6 +7,16 @@ var/savefile/borderControlFile = new /savefile("data/bordercontrol.db")
 var/whitelistLoaded = 0
 
 //////////////////////////////////////////////////////////////////////////////////
+proc/BC_ModeToText(var/mode)
+	switch(mode)
+		if(BORDER_CONTROL_DISABLED)
+			return "Disabled"
+		if(BORDER_CONTROL_LEARNING)
+			return "Learning"
+		if(BORDER_CONTROL_ENFORCED)
+			return "Enforced"
+
+//////////////////////////////////////////////////////////////////////////////////
 proc/BC_IsKeyAllowedToConnect(var/key)
 	key = ckey(key)
 
@@ -105,7 +115,7 @@ proc/BC_WhitelistKey(var/key)
 	set name = "Border Control - Toggle Mode"
 	set category = "Admin"
 
-	var/choice = input("New State", "Border Control State") as null|anything in list("Disabled", "Learning", "Enforced")
+	var/choice = input("New State (Current state is: [BC_ModeToText(config.borderControl)])", "Border Control State") as null|anything in list("Disabled", "Learning", "Enforced")
 
 	switch(choice)
 		if("Disabled")


### PR DESCRIPTION
…ent mode of border control.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->